### PR TITLE
Remove semantic-release from peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,9 +82,6 @@
     ],
     "all": true
   },
-  "peerDependencies": {
-    "semantic-release": ">= 8"
-  },
   "prettier": {
     "printWidth": 120,
     "singleQuote": true,


### PR DESCRIPTION
Unnecessary for default plugins.
Avoid a warning when installing `semantic-release`.