### PR TITLE
Call github API to determine the Travis API to use (pro / regular)

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
   },
   "dependencies": {
     "@semantic-release/error": "^2.0.0",
+    "github": "^11.0.0",
+    "parse-github-repo-url": "^1.4.1",
     "semver": "^5.0.3",
-    "travis-deploy-once": "^2.0.1"
+    "travis-deploy-once": "^3.0.0"
   },
   "devDependencies": {
     "ava": "^0.22.0",
@@ -29,13 +31,14 @@
     "eslint-plugin-prettier": "^2.3.0",
     "eslint-plugin-promise": "^3.5.0",
     "eslint-plugin-standard": "^3.0.1",
+    "nock": "^9.0.22",
     "nyc": "^11.2.1",
     "pify": "^3.0.0",
     "prettier": "^1.7.2",
     "proxyquire": "^1.7.1",
     "rimraf": "^2.6.2",
     "semantic-release": "^8.0.0",
-    "simple-mock": "^0.8.0"
+    "sinon": "^4.0.0"
   },
   "engines": {
     "node": ">=4"

--- a/test/condition-travis-test.js
+++ b/test/condition-travis-test.js
@@ -1,120 +1,273 @@
 import test from 'ava';
 import pify from 'pify';
 import proxyquire from 'proxyquire';
-import simple from 'simple-mock';
+import {stub} from 'sinon';
+import nock from 'nock';
+import {authenticate} from './helpers/mock-github';
 import SemanticReleaseError from '@semantic-release/error';
 
-const conditionMock = {'travis-deploy-once': () => {}};
+test.afterEach.always(t => {
+  // Reset nock
+  nock.cleanAll();
+});
 
-test('only runs on travis', async t => {
-  const condition = proxyquire.noCallThru()('../', conditionMock);
+test('Only runs on travis', async t => {
+  const travisDeployOnce = stub();
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
   const error = await t.throws(pify(condition)({}, {env: {}}));
 
   t.true(error instanceof SemanticReleaseError);
   t.is(error.code, 'ENOTRAVIS');
+  t.true(travisDeployOnce.notCalled);
 });
 
-test('not running on pull requests', async t => {
-  const condition = proxyquire.noCallThru()('../', conditionMock);
+test('Not running on pull requests', async t => {
+  const travisDeployOnce = stub();
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
   const error = await t.throws(pify(condition)({}, {env: {TRAVIS: 'true', TRAVIS_PULL_REQUEST: '105'}}));
 
   t.true(error instanceof SemanticReleaseError);
   t.is(error.code, 'EPULLREQUEST');
+  t.true(travisDeployOnce.notCalled);
 });
 
-test('not running on tags', async t => {
-  const condition = proxyquire.noCallThru()('../', conditionMock);
+test('Not running on tags', async t => {
+  const travisDeployOnce = stub();
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
   const error = await t.throws(
     pify(condition)({}, {env: {TRAVIS: 'true', TRAVIS_PULL_REQUEST: 'false', TRAVIS_TAG: 'v1.0.0'}})
   );
 
   t.true(error instanceof SemanticReleaseError);
   t.is(error.code, 'EGITTAG');
+  t.true(travisDeployOnce.notCalled);
 });
 
-test('not running on tags that don’t look like semantic versions', async t => {
-  const condition = proxyquire.noCallThru()('../', conditionMock);
+test('Not running on tags that don’t look like semantic versions', async t => {
+  const travisDeployOnce = stub();
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
   const error = await t.throws(
     pify(condition)({}, {env: {TRAVIS: 'true', TRAVIS_PULL_REQUEST: 'false', TRAVIS_TAG: 'vfoo'}})
   );
 
   t.true(error instanceof SemanticReleaseError);
   t.is(error.code, 'EGITTAG');
+  t.true(travisDeployOnce.notCalled);
 });
 
-test('only runs on master by default', async t => {
-  simple.mock(conditionMock, 'travis-deploy-once').resolveWith(true);
+test('Does not run on non-master branch by default', async t => {
+  const travisDeployOnce = stub();
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
 
-  const condition = proxyquire.noCallThru()('../', conditionMock);
-  const result = await pify(condition)(
-    {},
-    {env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'}, options: {branch: 'master'}}
-  );
-  t.falsy(result);
-});
-
-test('does not run on non-master branch by default', async t => {
-  simple.mock(conditionMock, 'travis-deploy-once').resolveWith(true);
-
-  const condition = proxyquire.noCallThru()('../', conditionMock);
   const error = await t.throws(
     pify(condition)({}, {env: {TRAVIS: 'true', TRAVIS_BRANCH: 'notmaster'}, options: {branch: 'master'}})
   );
 
   t.true(error instanceof SemanticReleaseError);
   t.is(error.code, 'EBRANCHMISMATCH');
+  t.true(travisDeployOnce.notCalled);
 });
 
-test('does not run on master if branch configured as "foo"', async t => {
-  const condition = proxyquire.noCallThru()('../', conditionMock);
+test('Does not run on master if branch configured as "foo"', async t => {
+  const travisDeployOnce = stub();
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
   const error = await t.throws(
     pify(condition)({}, {env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'}, options: {branch: 'foo'}})
   );
 
   t.true(error instanceof SemanticReleaseError);
   t.is(error.code, 'EBRANCHMISMATCH');
+  t.true(travisDeployOnce.notCalled);
 });
 
-test('travis-deploy-once resolves with true', async t => {
-  simple.mock(conditionMock, 'travis-deploy-once').resolveWith(true);
+test.serial('travis-deploy-once resolves with true', async t => {
+  const travisDeployOnce = stub().resolves(true);
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const githubToken = 'github_token';
+  const pro = false;
+  const github = authenticate({githubToken})
+    .get(`/repos/${owner}/${repo}`)
+    .reply(200, {private: pro});
 
-  const condition = proxyquire.noCallThru()('../', conditionMock);
   const result = await pify(condition)(
     {},
-    {env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'}, options: {branch: 'master'}}
+    {
+      pkg: {repository: {url: `git+https://github.com/${owner}/${repo}.git`}},
+      env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'},
+      options: {branch: 'master', githubToken},
+    }
   );
+
   t.falsy(result);
+  t.true(travisDeployOnce.calledOnce);
+  t.deepEqual(travisDeployOnce.firstCall.args[0], {travisOpts: {pro}});
+  t.true(github.isDone());
 });
 
-test('travis-deploy-once resolves with null', async t => {
-  simple.mock(conditionMock, 'travis-deploy-once').resolveWith(null);
+test.serial('travis-deploy-once resolves with null', async t => {
+  const travisDeployOnce = stub().resolves(null);
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const githubToken = 'github_token';
+  const pro = false;
+  const github = authenticate({githubToken})
+    .get(`/repos/${owner}/${repo}`)
+    .reply(200, {private: pro});
 
-  const condition = proxyquire.noCallThru()('../', conditionMock);
   const error = await t.throws(
-    pify(condition)({}, {env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'}, options: {branch: 'master'}})
+    pify(condition)(
+      {},
+      {
+        pkg: {repository: {url: `git+https://github.com/${owner}/${repo}.git`}},
+        env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'},
+        options: {branch: 'master', githubToken},
+      }
+    )
   );
+
   t.true(error instanceof SemanticReleaseError);
   t.is(error.code, 'ENOBUILDLEADER');
+  t.true(travisDeployOnce.calledOnce);
+  t.deepEqual(travisDeployOnce.firstCall.args[0], {travisOpts: {pro}});
+  t.true(github.isDone());
 });
 
-test('travis-deploy-once resolves with false', async t => {
-  simple.mock(conditionMock, 'travis-deploy-once').resolveWith(false);
+test.serial('travis-deploy-once resolves with false', async t => {
+  const travisDeployOnce = stub().resolves(false);
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const githubToken = 'github_token';
+  const pro = false;
+  const github = authenticate({githubToken})
+    .get(`/repos/${owner}/${repo}`)
+    .reply(200, {private: pro});
 
-  const condition = proxyquire.noCallThru()('../', conditionMock);
   const error = await t.throws(
-    pify(condition)({}, {env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'}, options: {branch: 'master'}})
+    pify(condition)(
+      {},
+      {
+        pkg: {repository: {url: `git+https://github.com/${owner}/${repo}.git`}},
+        env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'},
+        options: {branch: 'master', githubToken},
+      }
+    )
   );
+
   t.true(error instanceof SemanticReleaseError);
   t.is(error.code, 'EOTHERSFAILED');
+  t.true(travisDeployOnce.calledOnce);
+  t.deepEqual(travisDeployOnce.firstCall.args[0], {travisOpts: {pro}});
+  t.true(github.isDone());
 });
 
-test('travis-deploy-once rejects with error', async t => {
-  simple.mock(conditionMock, 'travis-deploy-once').rejectWith(new Error());
+test.serial('travis-deploy-once rejects with error', async t => {
+  const travisDeployOnce = stub().rejects(new Error('travis-deploy-once error'));
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const githubToken = 'github_token';
+  const pro = false;
+  const github = authenticate({githubToken})
+    .get(`/repos/${owner}/${repo}`)
+    .reply(200, {private: pro});
 
-  const condition = proxyquire.noCallThru()('../', conditionMock);
   const error = await t.throws(
-    pify(condition)({}, {env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'}, options: {branch: 'master'}})
+    pify(condition)(
+      {},
+      {
+        pkg: {repository: {url: `git+https://github.com/${owner}/${repo}.git`}},
+        env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'},
+        options: {branch: 'master', githubToken},
+      }
+    )
   );
+
   t.true(error instanceof Error);
-  t.truthy(error);
+  t.is(error.message, 'travis-deploy-once error');
+  t.true(travisDeployOnce.calledOnce);
+  t.deepEqual(travisDeployOnce.firstCall.args[0], {travisOpts: {pro}});
+  t.true(github.isDone());
+});
+
+test.serial('Throws an error if github call fails', async t => {
+  const travisDeployOnce = stub();
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const githubToken = 'github_token';
+  const github = authenticate({githubToken})
+    .get(`/repos/${owner}/${repo}`)
+    .reply(401);
+
+  const error = await t.throws(
+    pify(condition)(
+      {},
+      {
+        pkg: {repository: {url: `git+https://github.com/${owner}/${repo}.git`}},
+        env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'},
+        options: {branch: 'master', githubToken},
+      }
+    )
+  );
+
+  t.true(error instanceof Error);
+  t.is(error.code, 401);
+  t.true(github.isDone());
+});
+
+test.serial('Calls travis-run-once with pro parameter determined by github call', async t => {
+  const travisDeployOnce = stub().resolves(true);
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const githubToken = 'github_token';
+  const pro = true;
+  const github = authenticate({githubToken})
+    .get(`/repos/${owner}/${repo}`)
+    .reply(200, {private: pro});
+
+  const result = await pify(condition)(
+    {},
+    {
+      pkg: {repository: {url: `git+https://github.com/${owner}/${repo}.git`}},
+      env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'},
+      options: {branch: 'master', githubToken},
+    }
+  );
+
+  t.falsy(result);
+  t.true(travisDeployOnce.calledOnce);
+  t.deepEqual(travisDeployOnce.firstCall.args[0], {travisOpts: {pro}});
+  t.true(github.isDone());
+});
+
+test.serial('Calls travis-run-once with pro parameter determined by github call with githubUrl', async t => {
+  const travisDeployOnce = stub().resolves(true);
+  const condition = proxyquire('../', {'travis-deploy-once': travisDeployOnce});
+  const owner = 'test_user';
+  const repo = 'test_repo';
+  const githubToken = 'github_token';
+  const pro = true;
+  const githubUrl = 'https://testurl.com:443';
+  const github = authenticate({githubToken, githubUrl})
+    .get(`/repos/${owner}/${repo}`)
+    .reply(200, {private: pro});
+
+  const result = await pify(condition)(
+    {},
+    {
+      pkg: {repository: {url: `git+https://github.com/${owner}/${repo}.git`}},
+      env: {TRAVIS: 'true', TRAVIS_BRANCH: 'master'},
+      options: {branch: 'master', githubToken, githubUrl},
+    }
+  );
+
+  t.falsy(result);
+  t.true(travisDeployOnce.calledOnce);
+  t.deepEqual(travisDeployOnce.firstCall.args[0], {travisOpts: {pro}});
+  t.true(github.isDone());
 });

--- a/test/helpers/mock-github.js
+++ b/test/helpers/mock-github.js
@@ -1,0 +1,7 @@
+import nock from 'nock';
+
+export function authenticate(
+  {githubToken = 'GH_TOKEN', githubUrl = 'https://api.github.com', githubApiPathPrefix = ''} = {}
+) {
+  return nock(`${githubUrl}/${githubApiPathPrefix}`, {reqheaders: {authorization: `token ${githubToken}`}});
+}


### PR DESCRIPTION
Will allow to use `semantic-release` with Github enterprise by using `githubUrl` and `githubApiPathPrefix`. Fix 

Ci job will have to be restarted once `travis-deploy-once` version `3.0.0` is released.

Fix semantic-release/semantic-release#375