### PR TITLE
GitHub options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,17 @@ Verify that `semantic-release` is running:
 -   on the right git branch and not on a PR build
 -   only after all other Travis jobs are successful (using [travis-deploy-once](https://github.com/semantic-release/travis-deploy-once))
 
-The plugin is used by default by [semantic-release](https://github.com/semantic-release/semantic-release) so no specific configuration is requiered in `package.json`.
+### Options
+
+| Option                | Description                                                          | Default                                                |
+| --------------------- | -------------------------------------------------------------------- | ------------------------------------------------------ |
+| `githubToken`         | **Required.** The Github token used to authenticate with Travis API. | `process.env.GH_TOKEN` or `process.env.GITHUB_TOKEN`   |
+| `githubUrl`           | The GitHub Enterprise endpoint.                                      | `process.env.GH_URL` or `process.env.GITHUB_URL`       |
+| `githubApiPathPrefix` | The GitHub Enterprise API prefix.                                    | `process.env.GH_PREFIX` or `process.env.GITHUB_PREFIX` |
+
+## Configuration
+
+The plugin is used by default by [semantic-release](https://github.com/semantic-release/semantic-release) so no specific configuration is requiered if `githubToken`, `githubUrl` and `githubApiPathPrefix` are set via environment variable.
 
 ## Travis configuration
 

--- a/index.js
+++ b/index.js
@@ -3,13 +3,11 @@ const GitHubApi = require('github');
 const parseSlug = require('parse-github-repo-url');
 const semver = require('semver');
 const deployOnce = require('travis-deploy-once');
+const resolveConfig = require('./lib/resolve-config');
 const SRError = require('@semantic-release/error');
 
-module.exports = async function(
-  pluginConfig,
-  {pkg, env, options: {branch, githubUrl, githubToken, githubApiPathPrefix} = {}},
-  callback
-) {
+module.exports = async function(pluginConfig, {pkg, env, options: {branch} = {}}, callback) {
+  const {githubToken, githubUrl, githubApiPathPrefix} = resolveConfig(pluginConfig);
   if (env.TRAVIS !== 'true') {
     return callback(
       new SRError(

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,0 +1,5 @@
+module.exports = ({githubToken, githubUrl, githubApiPathPrefix}) => ({
+  githubToken: githubToken || process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
+  githubUrl: githubUrl || process.env.GH_URL || process.env.GITHUB_URL,
+  githubApiPathPrefix: githubApiPathPrefix || process.env.GH_PREFIX || process.env.GITHUB_PREFIX,
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@semantic-release/condition-travis",
-  "description": "make sure only the right builds on travis get published",
+  "description": "Check Travis CI environment before publishing",
   "version": "0.0.0-development",
   "author": "Stephan Bönnemann <stephan@boennemann.me> (http://boennemann.me)",
   "bugs": {


### PR DESCRIPTION
`githubToken`, `githubUrl` and `githubApiPathPrefix` are not semantic-release options anymore. They now have to be set at the plugin level or via environment variables. See semantic-release/semantic-release#515

Fix #91