### PR TITLE
feat: add support for Travis Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,10 +18,11 @@ Verify that `semantic-release` is running:
 | `githubToken`         | **Required.** The Github token used to authenticate with Travis API. | `process.env.GH_TOKEN` or `process.env.GITHUB_TOKEN`   |
 | `githubUrl`           | The GitHub Enterprise endpoint.                                      | `process.env.GH_URL` or `process.env.GITHUB_URL`       |
 | `githubApiPathPrefix` | The GitHub Enterprise API prefix.                                    | `process.env.GH_PREFIX` or `process.env.GITHUB_PREFIX` |
+| `travisUrl`           | The Travis Enterprise endpoint.                                      | `process.env.TRAVIS_URL`                               |
 
 ## Configuration
 
-The plugin is used by default by [semantic-release](https://github.com/semantic-release/semantic-release) so no specific configuration is requiered if `githubToken`, `githubUrl` and `githubApiPathPrefix` are set via environment variable.
+The plugin is used by default by [semantic-release](https://github.com/semantic-release/semantic-release) so no specific configuration is required if `githubToken`, `githubUrl`, `githubApiPathPrefix` and `travisUrl` are set via environment variable.
 
 ## Travis configuration
 
@@ -42,7 +43,7 @@ after_success:
 
 ### With multiple jobs on different Node versions and OS
 
-If there is multiple Node version and OS configured, [travis-deploy-once](https://github.com/semantic-release/travis-deploy-once) will guarantee that `semantic-release` is executed on the highest Node version, after all other jobs are successful, without any additionnal configurations.
+If there are multiple Node versions and OSs configured, [travis-deploy-once](https://github.com/semantic-release/travis-deploy-once) will guarantee that `semantic-release` is executed on the highest Node version, after all other jobs are successful, without any additional configurations.
 
 ```yml
 language: node_js

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const SemanticReleaseError = require('@semantic-release/error');
 const resolveConfig = require('./lib/resolve-config');
 
 module.exports = async function(pluginConfig, {options: {branch, repositoryUrl}}) {
-  const {githubToken, githubUrl, githubApiPathPrefix} = resolveConfig(pluginConfig);
+  const {githubToken, githubUrl, githubApiPathPrefix, travisUrl} = resolveConfig(pluginConfig);
   if (process.env.TRAVIS !== 'true') {
     throw new SemanticReleaseError(
       'semantic-release didn’t run on Travis CI and therefore a new version won’t be published.\nYou can customize this behavior using "verifyConditions" plugins: git.io/sr-plugins',
@@ -48,7 +48,7 @@ module.exports = async function(pluginConfig, {options: {branch, repositoryUrl}}
 
   const {data: {private: pro}} = await github.repos.get({owner, repo});
 
-  const result = await deployOnce({travisOpts: {pro}});
+  const result = await deployOnce({travisOpts: {pro, enterprise: travisUrl}});
 
   if (result === null) {
     throw new SemanticReleaseError(

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,5 +1,6 @@
-module.exports = ({githubToken, githubUrl, githubApiPathPrefix}) => ({
+module.exports = ({githubToken, githubUrl, githubApiPathPrefix, travisUrl}) => ({
   githubToken: githubToken || process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
   githubUrl: githubUrl || process.env.GH_URL || process.env.GITHUB_URL,
   githubApiPathPrefix: githubApiPathPrefix || process.env.GH_PREFIX || process.env.GITHUB_PREFIX,
+  travisUrl: travisUrl || process.env.TRAVIS_URL,
 });


### PR DESCRIPTION
Pass on `travisUrl` as `travisOpts` to `travisDeployOnce`

Fixes #100

This is blocked by release of pwmckenna/node-travis-ci#22, and an update in `travis-deploy-once`.