### PR TITLE
fix(package): update travis-deploy-once

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@semantic-release/error": "^2.0.0",
     "github": "^13.0.1",
     "parse-github-url": "^1.0.1",
-    "travis-deploy-once": "^3.0.0"
+    "travis-deploy-once": "^3.1.0"
   },
   "devDependencies": {
     "ava": "^0.24.0",


### PR DESCRIPTION
Makes sure Travis Enterprise is supported

Complements #101.

When I removed the override in my project and got the latest `condition-travis`, `travis-deploy-once` was not updated. This ensures a new versions is installed.