### PR TITLE
fix: add travisApiPrefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Verify that `semantic-release` is running:
 | `githubUrl`           | The GitHub Enterprise endpoint.                                      | `process.env.GH_URL` or `process.env.GITHUB_URL`       |
 | `githubApiPathPrefix` | The GitHub Enterprise API prefix.                                    | `process.env.GH_PREFIX` or `process.env.GITHUB_PREFIX` |
 | `travisUrl`           | The Travis Enterprise endpoint.                                      | `process.env.TRAVIS_URL`                               |
+| `travisApiPathPrefix` | The Travis Enterprise API prefix.                                    | `process.env.TRAVIS_PREFIX`                               |
 
 ## Configuration
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const SemanticReleaseError = require('@semantic-release/error');
 const resolveConfig = require('./lib/resolve-config');
 
 module.exports = async function(pluginConfig, {options: {branch, repositoryUrl}}) {
-  const {githubToken, githubUrl, githubApiPathPrefix, travisUrl} = resolveConfig(pluginConfig);
+  const {githubToken, githubUrl, githubApiPathPrefix, travisUrl, travisApiPathPrefix} = resolveConfig(pluginConfig);
   if (process.env.TRAVIS !== 'true') {
     throw new SemanticReleaseError(
       'semantic-release didn’t run on Travis CI and therefore a new version won’t be published.\nYou can customize this behavior using "verifyConditions" plugins: git.io/sr-plugins',
@@ -46,7 +46,8 @@ module.exports = async function(pluginConfig, {options: {branch, repositoryUrl}}
 
   const {data: {private: pro}} = await github.repos.get({owner, repo});
 
-  const result = await deployOnce({travisOpts: {pro, enterprise: travisUrl}});
+  const travisEnterpriseUrl = travisUrl ? travisUrl + travisApiPathPrefix : undefined;
+  const result = await deployOnce({travisOpts: {pro, enterprise: travisEnterpriseUrl}});
 
   if (result === null) {
     throw new SemanticReleaseError(

--- a/lib/resolve-config.js
+++ b/lib/resolve-config.js
@@ -1,6 +1,7 @@
-module.exports = ({githubToken, githubUrl, githubApiPathPrefix, travisUrl}) => ({
+module.exports = ({githubToken, githubUrl, githubApiPathPrefix, travisUrl, travisApiPathPrefix}) => ({
   githubToken: githubToken || process.env.GH_TOKEN || process.env.GITHUB_TOKEN,
   githubUrl: githubUrl || process.env.GH_URL || process.env.GITHUB_URL,
   githubApiPathPrefix: githubApiPathPrefix || process.env.GH_PREFIX || process.env.GITHUB_PREFIX,
   travisUrl: travisUrl || process.env.TRAVIS_URL,
+  travisApiPathPrefix: travisApiPathPrefix || process.env.TRAVIS_PREFIX || '',
 });

--- a/test/condition-travis-test.js
+++ b/test/condition-travis-test.js
@@ -19,6 +19,7 @@ test.beforeEach(t => {
   delete process.env.TRAVIS_PULL_REQUEST;
   delete process.env.TRAVIS_BRANCH;
   delete process.env.TRAVIS_URL;
+  delete process.env.TRAVIS_PREFIX;
 });
 
 test.afterEach.always(t => {
@@ -271,6 +272,7 @@ test.serial('Calls travis-run-once with enterprise parameter', async t => {
   const githubToken = 'github_token';
   const pro = false;
   const travisUrl = 'https://travis.example.com';
+  const travisApiPathPrefix = '/api';
   const github = authenticate({githubToken})
     .get(`/repos/${owner}/${repo}`)
     .reply(200, {private: pro});
@@ -278,12 +280,12 @@ test.serial('Calls travis-run-once with enterprise parameter', async t => {
   process.env.TRAVIS_BRANCH = 'master';
 
   const result = await condition(
-    {githubToken, travisUrl},
+    {githubToken, travisUrl, travisApiPathPrefix},
     {options: {branch: 'master', repositoryUrl: `git+https://github.com/${owner}/${repo}.git`}}
   );
 
   t.falsy(result);
   t.true(travisDeployOnce.calledOnce);
-  t.deepEqual(travisDeployOnce.firstCall.args[0], {travisOpts: {pro, enterprise: travisUrl}});
+  t.deepEqual(travisDeployOnce.firstCall.args[0], {travisOpts: {pro, enterprise: travisUrl + travisApiPathPrefix}});
   t.true(github.isDone());
 });


### PR DESCRIPTION
This matches the schema of github options.

This is technically not needed, as we could just expect users to add `/api` themselves. Thoughts?