### PR TITLE
fix(package): update travis-deploy-once for travis enterprise

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@semantic-release/error": "^2.0.0",
     "github": "^13.0.1",
     "parse-github-url": "^1.0.1",
-    "travis-deploy-once": "^3.1.0"
+    "travis-deploy-once": "^3.1.2"
   },
   "devDependencies": {
     "ava": "^0.24.0",


### PR DESCRIPTION
Updating ensures that the README has correct instructions for Travis enterprise